### PR TITLE
Añadidas las librerias de apc

### DIFF
--- a/ansible/group_vars/all/php.yml
+++ b/ansible/group_vars/all/php.yml
@@ -15,4 +15,5 @@ php_packages:
   - php-pecl-xdebug
   - php-bcmath
   - php-devel
+  - php-apc
 php_display_errors: "On"


### PR DESCRIPTION
- Cuando se ejecuta cualquier aplicación con php da un warning indicando que le falta las librerías de apc. Modificando el php.yml se añaden y queda resuelto el error.